### PR TITLE
L2 yield message service

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -19,5 +19,6 @@ additional_compiler_profiles = [ { name = "london", evm_version = "london" } ]
 # Specify EVM_VERSION restrictions for contract compilation
 compilation_restrictions = [
     { paths = "./**/L2MessageService.sol", evm_version = "london" },
+    { paths = "./**/L2YieldMessageService.sol", evm_version = "london" },
     { paths = "./**/TokenBridge.sol", evm_version = "london" },
 ]

--- a/contracts/src/messaging/l2/v1/L2MessageServiceV1.sol
+++ b/contracts/src/messaging/l2/v1/L2MessageServiceV1.sol
@@ -121,7 +121,7 @@ abstract contract L2MessageServiceV1 is
     address payable _feeRecipient,
     bytes calldata _calldata,
     uint256 _nonce
-  ) external nonReentrant distributeFees(_fee, _to, _calldata, _feeRecipient) {
+  ) public virtual nonReentrant distributeFees(_fee, _to, _calldata, _feeRecipient) {
     _requireTypeAndGeneralNotPaused(PauseType.L1_L2);
 
     bytes32 messageHash = MessageHashing._hashMessage(_from, _to, _fee, _value, _nonce, _calldata);

--- a/contracts/src/yield/bridge/L2YieldMessageService.sol
+++ b/contracts/src/yield/bridge/L2YieldMessageService.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.19;
+
+import { L2MessageService } from "../../messaging/l2/L2MessageService.sol";
+
+contract L2YieldMessageService is L2MessageService {
+  error L2YieldMessageService__InvalidValue();
+
+  function claimMessage(
+    address _from,
+    address _to,
+    uint256 _fee,
+    uint256 _value,
+    address payable _feeRecipient,
+    bytes calldata _calldata,
+    uint256 _nonce
+  ) public override {
+    if (_value > 0) {
+      revert L2YieldMessageService__InvalidValue();
+    }
+
+    super.claimMessage(_from, _to, _fee, _value, _feeRecipient, _calldata, _nonce);
+  }
+}
+

--- a/contracts/test/foundry/yield/bridge/L1ETHBridge.t.sol
+++ b/contracts/test/foundry/yield/bridge/L1ETHBridge.t.sol
@@ -26,9 +26,7 @@ contract L1ETHBridgeTest is Test {
     yieldManager = ETHYieldManagerMock(payable(bridge.yieldManager()));
     l2ETHBridge = bridge.l2ETHBridge();
   }
-}
 
-contract BridgeETHTest is L1ETHBridgeTest {
   function test_RevertsIfYieldManagerIsNotSet() public {
     vm.prank(deployer);
     bridge.setYieldManager(address(0));

--- a/contracts/test/foundry/yield/bridge/L2YieldMessageService.t.sol
+++ b/contracts/test/foundry/yield/bridge/L2YieldMessageService.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.8.19;
+
+import { Test } from "forge-std/Test.sol";
+import { L2MessageService } from "../../../../src/messaging/l2/L2MessageService.sol";
+import { L2YieldMessageService } from "../../../../src/yield/bridge/L2YieldMessageService.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { IPermissionsManager } from "../../../../src/security/access/interfaces/IPermissionsManager.sol";
+import { IPauseManager } from "../../../../src/security/pausing/interfaces/IPauseManager.sol";
+
+contract L2YieldMessageServiceTest is Test {
+    L2YieldMessageService yieldMessageService;
+    address defaultAdmin = makeAddr("defaultAdmin");
+    
+    function setUp() public {
+        L2YieldMessageService implementation  = new L2YieldMessageService();
+        bytes memory initializer = abi.encodeWithSelector(L2MessageService.initialize.selector, 
+            86400,
+            100 ether,
+            defaultAdmin,
+            new IPermissionsManager.RoleAddress[](0),
+            new IPauseManager.PauseTypeRole[](0),
+            new IPauseManager.PauseTypeRole[](0)
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), initializer);
+        yieldMessageService = L2YieldMessageService(address(proxy));
+    }
+
+    function test_RevertWhenValueIsGreaterThanZero() public {
+        vm.expectRevert("L2YieldMessageService__InvalidValue()");
+        yieldMessageService.claimMessage(
+            makeAddr("from"),
+            makeAddr("to"),
+            0,
+            1,
+            payable(defaultAdmin),
+            hex"00",
+            0
+        );
+    }
+}


### PR DESCRIPTION
closes #19 

### features

* add L2YieldMessageService inheriting from L2MessageService
* override claimMessage
* revert if value > 0
* revert if the recipient is L2ETHBridge but the L1 sender is not L1ETHBridge
* add setters for L1ETHBridge and L2ETHBridge addresses 