### PR TITLE
L1ETHBridge inherits from MessageServiceBase

### DIFF
--- a/contracts/scripts/yield/bridge/l1/DeployL1ETHBridge.s.sol
+++ b/contracts/scripts/yield/bridge/l1/DeployL1ETHBridge.s.sol
@@ -10,13 +10,13 @@ import { L1ETHBridge } from "../../../../src/yield/bridge/L1ETHBridge.sol";
 contract DeployL1ETHBridge is BaseScript {
   function run() public returns (address, L1ETHBridge) {
     DeploymentConfig deploymentConfig = new DeploymentConfig(broadcaster);
-    (address deployer, address rollup, address yieldManager, address l2ETHBridge) = deploymentConfig
+    (address deployer, address messageService, address remoteSender, address yieldManager) = deploymentConfig
       .activeNetworkConfig();
 
     vm.startBroadcast(deployer);
 
     L1ETHBridge impl = new L1ETHBridge();
-    bytes memory initializeData = abi.encodeCall(L1ETHBridge.initialize, (deployer, rollup, yieldManager, l2ETHBridge));
+    bytes memory initializeData = abi.encodeCall(L1ETHBridge.initialize, (deployer, messageService, remoteSender, yieldManager));
 
     address proxy = address(new ERC1967Proxy(address(impl), initializeData));
 

--- a/contracts/scripts/yield/bridge/l1/DeploymentConfig.s.sol
+++ b/contracts/scripts/yield/bridge/l1/DeploymentConfig.s.sol
@@ -11,9 +11,9 @@ contract DeploymentConfig is Script {
 
   struct NetworkConfig {
     address deployer;
-    address rollup;
+    address messageService;
+    address remoteSender;
     address yieldManager;
-    address l2ETHBridge;
   }
 
   NetworkConfig public activeNetworkConfig;
@@ -32,14 +32,14 @@ contract DeploymentConfig is Script {
 
   function getOrCreateAnvilEthConfig(address _deployer) public returns (NetworkConfig memory) {
     ETHYieldManagerMock yieldManager = new ETHYieldManagerMock();
-    RollupMock rollup = new RollupMock();
+    RollupMock rollupMock = new RollupMock();
 
     return
       NetworkConfig({
         deployer: _deployer,
-        rollup: address(rollup),
-        yieldManager: address(yieldManager),
-        l2ETHBridge: makeAddr("l2ETHBridge")
+        messageService: address(rollupMock),
+        remoteSender: makeAddr("remoteSender"),
+        yieldManager: address(yieldManager)
       });
   }
 

--- a/contracts/src/yield/bridge/L1ETHBridge.sol
+++ b/contracts/src/yield/bridge/L1ETHBridge.sol
@@ -7,38 +7,15 @@ import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/O
 
 import { IRollup } from "./interfaces/IRollup.sol";
 import { IL2ETHBridge } from "./interfaces/IL2ETHBridge.sol";
+import { MessageServiceBase } from "../../messaging/MessageServiceBase.sol";
+import { IMessageService } from "../../messaging/interfaces/IMessageService.sol";
 
-contract L1ETHBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract L1ETHBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable, MessageServiceBase {
   error L1ETHBridge__ZeroValue();
-  error L1ETHBridge__RollupAddressNotSet();
-  error L1ETHBridge__YieldManagerNotSet();
+  error L1ETHBridge__ZeroAddressNotAllowed();
   error L1ETHBridge__YieldManagerDepositFailed();
-  error L1ETHBridge__L2ETHBridgeNotSet();
 
-  address public rollup;
   address public yieldManager;
-  address public l2ETHBridge;
-
-  modifier rollupIsSet() {
-    if (rollup == address(0)) {
-      revert L1ETHBridge__RollupAddressNotSet();
-    }
-    _;
-  }
-
-  modifier yieldManagerIsSet() {
-    if (yieldManager == address(0)) {
-      revert L1ETHBridge__YieldManagerNotSet();
-    }
-    _;
-  }
-
-  modifier l2ETHBridgeIsSet() {
-    if (l2ETHBridge == address(0)) {
-      revert L1ETHBridge__L2ETHBridgeNotSet();
-    }
-    _;
-  }
 
   /**
    * @notice Disables initializers to prevent reinitialization.
@@ -50,28 +27,44 @@ contract L1ETHBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable {
   /**
    * @notice Initializes the contract.
    * @param _initialOwner The initial owner of the contract.
-   * @param _rollup The rollup address.
+   * @param _messageService The message service address (previously rollup).
    * @param _yieldManager The yield manager address.
-   * @param _l2ETHBridge The L2ETHBridge address.
+   * @param _remoteSender The remote sender address (previously l2ETHBridge).
    */
   function initialize(
     address _initialOwner,
-    address _rollup,
-    address _yieldManager,
-    address _l2ETHBridge
+    address _messageService,
+    address _remoteSender,
+    address _yieldManager
   ) external initializer {
     _transferOwnership(_initialOwner);
-    rollup = _rollup;
+    __MessageServiceBase_init(_messageService);
+    _setRemoteSender(_remoteSender);
+
+    if (_yieldManager == address(0)) {
+      revert L1ETHBridge__ZeroAddressNotAllowed();
+    }
     yieldManager = _yieldManager;
-    l2ETHBridge = _l2ETHBridge;
   }
 
   /**
-   * @notice Sets the rollup address.
-   * @param _rollup The new rollup address.
+   * @notice Sets the message service address.
+   * @param _messageService The new message service address.
    */
-  function setRollup(address _rollup) external onlyOwner {
-    rollup = _rollup;
+  function setMessageService(address _messageService) external onlyOwner {
+    if (_messageService == address(0)) {
+      revert L1ETHBridge__ZeroAddressNotAllowed();
+    }
+
+    messageService = IMessageService(_messageService);
+  }
+
+  /**
+   * @notice Sets the remote sender address.
+   * @param _remoteSender The new remote sender address.
+   */
+  function setRemoteSender(address _remoteSender) external onlyOwner {
+    _setRemoteSender(_remoteSender);
   }
 
   /**
@@ -79,15 +72,11 @@ contract L1ETHBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable {
    * @param _yieldManager The new yield manager address.
    */
   function setYieldManager(address _yieldManager) external onlyOwner {
-    yieldManager = _yieldManager;
-  }
+    if (_yieldManager == address(0)) {
+      revert L1ETHBridge__ZeroAddressNotAllowed();
+    }
 
-  /**
-   * @notice Sets the L2ETHBridge address.
-   * @param _l2ETHBridge The new L2ETHBridge address.
-   */
-  function setL2ETHBridge(address _l2ETHBridge) external onlyOwner {
-    l2ETHBridge = _l2ETHBridge;
+    yieldManager = _yieldManager;
   }
 
   /**
@@ -98,7 +87,7 @@ contract L1ETHBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable {
   function bridgeETH(
     address _to,
     bytes memory _calldata
-  ) external payable rollupIsSet yieldManagerIsSet l2ETHBridgeIsSet {
+  ) external payable {
     if (msg.value == 0) {
       revert L1ETHBridge__ZeroValue();
     }
@@ -109,7 +98,7 @@ contract L1ETHBridge is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     }
 
     bytes memory data = abi.encodeWithSelector(IL2ETHBridge.completeBridge.selector, _to, msg.value, _calldata);
-    IRollup(rollup).sendMessage(l2ETHBridge, 0, data);
+    messageService.sendMessage(remoteSender, 0, data);
   }
 
   function _authorizeUpgrade(address) internal view override {

--- a/contracts/test/foundry/yield/bridge/L1ETHBridge.t.sol
+++ b/contracts/test/foundry/yield/bridge/L1ETHBridge.t.sol
@@ -11,44 +11,59 @@ import { ETHYieldManagerMock } from "./mocks/ETHYieldManagerMock.sol";
 
 contract L1ETHBridgeTest is Test {
   L1ETHBridge bridge;
-  RollupMock rollup;
+  RollupMock messageService;
   ETHYieldManagerMock yieldManager;
 
   address deployer;
-  address l2ETHBridge;
+  address remoteSender;
   address user1 = makeAddr("user1");
   address user2 = makeAddr("user2");
 
   function setUp() public {
     DeployL1ETHBridge script = new DeployL1ETHBridge();
     (deployer, bridge) = script.run();
-    rollup = RollupMock(bridge.rollup());
+    messageService = RollupMock(address(bridge.messageService()));
     yieldManager = ETHYieldManagerMock(payable(bridge.yieldManager()));
-    l2ETHBridge = bridge.l2ETHBridge();
+    remoteSender = bridge.remoteSender();
   }
 
-  function test_RevertsIfYieldManagerIsNotSet() public {
+  function test_setYieldManagerRevertsIfZeroAddress() public {
     vm.prank(deployer);
+    vm.expectRevert("L1ETHBridge__ZeroAddressNotAllowed()");
     bridge.setYieldManager(address(0));
-
-    vm.expectRevert("L1ETHBridge__YieldManagerNotSet()");
-    bridge.bridgeETH(address(0), "");
   }
 
-  function test_RevertsIfRollupIsNotSet() public {
+  function test_setYieldManagerSetsYieldManager() public {
     vm.prank(deployer);
-    bridge.setRollup(address(0));
-
-    vm.expectRevert("L1ETHBridge__RollupAddressNotSet()");
-    bridge.bridgeETH(address(0), "");
+    address newYieldManager = makeAddr("new-yieldManager");
+    bridge.setYieldManager(newYieldManager);
+    assertEq(bridge.yieldManager(), newYieldManager);
   }
 
-  function test_RevertsIfL2ETHBridgeIsNotSet() public {
+  function test_setRemoteSenderRevertsIfZeroAddress() public {
     vm.prank(deployer);
-    bridge.setL2ETHBridge(address(0));
+    vm.expectRevert("ZeroAddressNotAllowed()");
+    bridge.setRemoteSender(address(0));
+  }
 
-    vm.expectRevert("L1ETHBridge__L2ETHBridgeNotSet()");
-    bridge.bridgeETH(address(0), "");
+  function test_setMessageServiceRevertsIfZeroAddress() public {
+    vm.prank(deployer);
+    vm.expectRevert("L1ETHBridge__ZeroAddressNotAllowed()");
+    bridge.setMessageService(address(0));
+  }
+
+  function test_setMessageServiceSetsMessageService() public {
+    vm.prank(deployer);
+    address newMessageService = makeAddr("new-messageService");
+    bridge.setMessageService(newMessageService);
+    assertEq(address(bridge.messageService()), newMessageService);
+  }
+
+  function test_setRemoteSenderSetsRemoteSender() public {
+    vm.prank(deployer);
+    address newRemoteSender = makeAddr("new-remoteSender");   
+    bridge.setRemoteSender(newRemoteSender);
+    assertEq(bridge.remoteSender(), newRemoteSender);
   }
 
   function test_RevertsIfValueIsZero() public {
@@ -73,7 +88,7 @@ contract L1ETHBridgeTest is Test {
     vm.prank(user1);
     bridge.bridgeETH{ value: 100 }(user2, "test-message");
 
-    assertEq(rollup.messagesLength(), 1);
+    assertEq(messageService.messagesLength(), 1);
 
     bytes memory expectedData = abi.encodeWithSelector(
       IL2ETHBridge.completeBridge.selector,
@@ -82,8 +97,8 @@ contract L1ETHBridgeTest is Test {
       "test-message"
     );
 
-    RollupMock.Message memory message = rollup.lastMessage();
-    assertEq(message.to, l2ETHBridge);
+    RollupMock.Message memory message = messageService.lastMessage();
+    assertEq(message.to, remoteSender);
     assertEq(message.fee, 0);
     assertEq(message.value, 0);
     assertEq(message.data, expectedData);


### PR DESCRIPTION
L1ETHBridge inherits from MessageServiceBase and makes sure addresses are not 0 in setter functions instead of checking in bridgeETH
